### PR TITLE
refactor: use `isTRUE(all.equal())` instead of `all.equal()` for checking boolean

### DIFF
--- a/R/crossvalidation.R
+++ b/R/crossvalidation.R
@@ -505,7 +505,7 @@ applyFolds <- function(object, folds = cv(rep(1, length(unique(object$id))), typ
   OOBweights <- matrix(rep(sample_weights, ncol(folds)), ncol = ncol(folds))
   OOBweights[folds > 0] <- 0
   
-  if (all.equal(papply, mclapply) == TRUE) {
+  if (isTRUE(all.equal(papply, mclapply))) {
     oobrisk <- papply(1:ncol(folds),
                       function(i) try(dummyfct(weights = folds[, i],
                                                oobweights = OOBweights[, i]),

--- a/R/utilityFunctions.R
+++ b/R/utilityFunctions.R
@@ -1107,7 +1107,7 @@ reweightData <- function(data, argvals, vars,
   
   ## check that all idvars are equal
   if(length(idvars)>1)
-    if(!all(sapply(data[idvars][-1],function(x)all.equal(data[idvars][[1]],x)=="TRUE")))
+    if(!all(sapply(data[idvars][-1],function(x) isTRUE(all.equal(data[idvars][[1]], x)))))
       stop("All idvars must be identical.")
   idvars_new <- NULL
   
@@ -1131,7 +1131,7 @@ reweightData <- function(data, argvals, vars,
     for(j in 1:length(nhm)){
       
       ## check that idvars == idvars[[1]] and match id-variables in all hmatrix-objects
-      if(!is.null(idvars) && !(all.equal(c(getId(data[[nhm[j]]])), c(data[[idvars[1]]])) == "TRUE")) 
+      if(!is.null(idvars) && !isTRUE(all.equal(c(getId(data[[nhm[j]]])), c(data[[idvars[1]]]))))
         stop("id variable in hmatrix object must be equal to idvars")
       
       ## subset hmatrix


### PR DESCRIPTION
closes: https://github.com/boost-R/FDboost/issues/26

`all.equal()` doesn't return `FALSE` but rather the differences, for reference: https://stat.ethz.ch/R-manual/R-devel/library/base/html/all.equal.html, https://stackoverflow.com/questions/3395696/whats-the-difference-between-identicalx-y-and-istrueall-equalx-y