### PR TITLE
ci: missing tiny tex installation

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -46,6 +46,15 @@ jobs:
           extra-packages: any::rcmdcheck
           needs: check
 
+      - uses: r-lib/actions/setup-tinytex@v2
+        env:
+          TINYTEX_INSTALLER: TinyTeX
+
+      - name: Install additional LaTeX packages
+        run: |
+          tlmgr update --self
+          tlmgr install doublestroke relsize
+
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 <!-- badges: start -->
 
+[![R-CMD-check](https://github.com/boost-R/FDboost/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/boost-R/FDboost/actions/workflows/R-CMD-check.yaml)
 [![CRAN status](https://www.r-pkg.org/badges/version/FDboost)](https://CRAN.R-project.org/package=FDboost)
 [![CRAN RStudio mirror downloads](https://cranlogs.r-pkg.org/badges/FDboost)](https://www.r-pkg.org/pkg/FDboost)
 


### PR DESCRIPTION
This fixes the r-cmd-check actions by installing the missing tinytex and required packages